### PR TITLE
Pause monthly auto-execution of publication update workflow

### DIFF
--- a/.github/workflows/update-publications.lock.yml
+++ b/.github/workflows/update-publications.lock.yml
@@ -47,8 +47,10 @@
 
 name: "月次業績自動追加エージェント"
 "on":
-  schedule:
-  - cron: "0 0 1 * *"
+  # 月次の自動実行は一時停止中（手動実行のみ有効）。
+  # 再開は update-publications.md の schedule を有効化し `gh aw compile` で再生成。
+  # schedule:
+  # - cron: "0 0 1 * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/.github/workflows/update-publications.md
+++ b/.github/workflows/update-publications.md
@@ -1,7 +1,9 @@
 ---
 on:
-  schedule:
-    - cron: '0 0 1 * *'   # 毎月1日 00:00 UTC (09:00 JST)
+  # 月次の自動実行は一時停止中。再開するには下記 schedule のコメントを解除し、
+  # `gh aw compile` で update-publications.lock.yml を再生成すること。
+  # schedule:
+  #   - cron: '0 0 1 * *'   # 毎月1日 00:00 UTC (09:00 JST)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Temporarily disabled the scheduled monthly execution of the publication update workflow. The workflow will now only run on manual trigger via `workflow_dispatch`.

## Changes
- Commented out the `schedule` trigger with cron expression `0 0 1 * *` (1st of each month at 00:00 UTC) in both the workflow definition and its source template
- Added clarifying comments explaining that monthly auto-execution is paused and how to re-enable it:
  - Uncomment the `schedule` section in `update-publications.md`
  - Regenerate the lock file using `gh aw compile`
- Preserved the `workflow_dispatch` trigger to allow manual execution

## Implementation Details
- Changes made in both `.github/workflows/update-publications.lock.yml` (compiled workflow) and `.github/workflows/update-publications.md` (source template) to keep them in sync
- Comments are in Japanese to match the existing codebase conventions

https://claude.ai/code/session_01Uh1MjvwEwxkSRkDWbAqkXK